### PR TITLE
Add workflow to release

### DIFF
--- a/.github/workflows/publish_and_tag.yml
+++ b/.github/workflows/publish_and_tag.yml
@@ -1,0 +1,44 @@
+# Workflow to send master to pypi and tag  the branch:
+# You need to edit FOLDER_WITH_VERSION with the folder that has the __version__ value. 
+
+name: master to pypi with comments and tag
+
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+
+env:
+  FOLDER_WITH_VERSION: deepfinder
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+        pip install scipion-pyworkflow 
+        pip install scipion-em
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/* -c "${{ secrets.PYPI_COMMENT }}"
+    - name: Get version and tag
+      run: |
+        export PACKAGE_VERSION=$(python -c "import $FOLDER_WITH_VERSION; print('VERSION', 'v'+$FOLDER_WITH_VERSION.__version__)" | grep VERSION | sed "s/VERSION //g")
+        git tag $PACKAGE_VERSION
+        git push origin $PACKAGE_VERSION

--- a/deepfinder/__init__.py
+++ b/deepfinder/__init__.py
@@ -27,7 +27,7 @@
 import pwem
 
 from .constants import *
-
+__version__ = '3.0.0a1'
 _logo = "icon.png"
 _references = ['EMMANUEL2020']
 

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ from setuptools import setup, find_packages
 # To use a consistent encoding
 from codecs import open
 from os import path
+from deepfinder import __version__
 
 here = path.abspath(path.dirname(__file__))
 
@@ -25,7 +26,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='scipion-em-deepfinder',  # Required
-    version='0.1',  # Required
+    version=__version__,  # Required
     description='Deepfinder plugin for scipion.',  # Required
     long_description=long_description,  # Optional
     url='https://github.com/scipion-em/scipion-em-deepfinder',  # Optional


### PR DESCRIPTION
Hi @emoebel ! I hope you are around!

This proposed change is to adapt the plugin to automatically release and tag the code of the release.

For that, we need to standardise de version--> __version__

The way this works is, any change in master branch will be automatically released to pypi.

It is using a pair of secrets that now are comming from the scipion-em organization, therfore they will be released as "scipion" and this will be the author in pypi.

I suggest overwriting the secrets, under this repo settings with your/you institution account of pypi. So you get the credit at pypi.

You should define:
PYPI_PASSWORD
and
PYPI_USERNAME
